### PR TITLE
Introduced explicit index resolution API

### DIFF
--- a/modules/reindex/src/test/java/org/opensearch/index/reindex/ReindexFromRemoteWithAuthTests.java
+++ b/modules/reindex/src/test/java/org/opensearch/index/reindex/ReindexFromRemoteWithAuthTests.java
@@ -39,6 +39,7 @@ import org.opensearch.action.admin.cluster.node.info.NodeInfo;
 import org.opensearch.action.search.SearchAction;
 import org.opensearch.action.support.ActionFilter;
 import org.opensearch.action.support.ActionFilterChain;
+import org.opensearch.action.support.ActionRequestMetadata;
 import org.opensearch.action.support.WriteRequest.RefreshPolicy;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
@@ -233,6 +234,7 @@ public class ReindexFromRemoteWithAuthTests extends OpenSearchSingleNodeTestCase
             Task task,
             String action,
             Request request,
+            ActionRequestMetadata<Request, Response> actionRequestMetadata,
             ActionListener<Response> listener,
             ActionFilterChain<Request, Response> chain
         ) {

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/AutoTaggingActionFilter.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/AutoTaggingActionFilter.java
@@ -13,6 +13,7 @@ import org.opensearch.action.IndicesRequest;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.support.ActionFilter;
 import org.opensearch.action.support.ActionFilterChain;
+import org.opensearch.action.support.ActionRequestMetadata;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.plugin.wlm.rule.attribute_extractor.IndicesExtractor;
@@ -51,6 +52,7 @@ public class AutoTaggingActionFilter implements ActionFilter {
         Task task,
         String action,
         Request request,
+        ActionRequestMetadata<Request, Response> actionRequestMetadata,
         ActionListener<Response> listener,
         ActionFilterChain<Request, Response> chain
     ) {

--- a/server/src/main/java/org/opensearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -35,6 +35,7 @@ package org.opensearch.action.admin.indices.alias;
 import org.opensearch.OpenSearchGenerationException;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.AliasesRequest;
+import org.opensearch.action.CompositeIndicesRequest;
 import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.action.support.clustermanager.AcknowledgedRequest;
 import org.opensearch.cluster.metadata.AliasAction;
@@ -76,7 +77,7 @@ import static org.opensearch.core.xcontent.ObjectParser.fromList;
  * @opensearch.api
  */
 @PublicApi(since = "1.0.0")
-public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesRequest> implements ToXContentObject {
+public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesRequest> implements ToXContentObject, CompositeIndicesRequest {
 
     private List<AliasActions> allAliasActions = new ArrayList<>();
     private String origin = "";

--- a/server/src/main/java/org/opensearch/action/admin/indices/create/TransportCreateIndexAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/create/TransportCreateIndexAction.java
@@ -33,12 +33,14 @@
 package org.opensearch.action.admin.indices.create;
 
 import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.TransportIndicesResolvingAction;
 import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.block.ClusterBlockException;
 import org.opensearch.cluster.block.ClusterBlockLevel;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.metadata.MetadataCreateIndexService;
+import org.opensearch.cluster.metadata.ResolvedIndices;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
@@ -54,7 +56,9 @@ import java.io.IOException;
  *
  * @opensearch.internal
  */
-public class TransportCreateIndexAction extends TransportClusterManagerNodeAction<CreateIndexRequest, CreateIndexResponse> {
+public class TransportCreateIndexAction extends TransportClusterManagerNodeAction<CreateIndexRequest, CreateIndexResponse>
+    implements
+        TransportIndicesResolvingAction<CreateIndexRequest> {
 
     private final MetadataCreateIndexService createIndexService;
     private final MappingTransformerRegistry mappingTransformerRegistry;
@@ -115,7 +119,7 @@ public class TransportCreateIndexAction extends TransportClusterManagerNodeActio
             cause = "api";
         }
 
-        final String indexName = indexNameExpressionResolver.resolveDateMathExpression(request.index());
+        final String indexName = resolveIndexName(request);
 
         final String finalCause = cause;
         final ActionListener<String> mappingTransformListener = ActionListener.wrap(transformedMappings -> {
@@ -143,4 +147,12 @@ public class TransportCreateIndexAction extends TransportClusterManagerNodeActio
         mappingTransformerRegistry.applyTransformers(request.mappings(), null, mappingTransformListener);
     }
 
+    @Override
+    public ResolvedIndices resolveIndices(CreateIndexRequest request) {
+        return ResolvedIndices.of(resolveIndexName(request));
+    }
+
+    private String resolveIndexName(CreateIndexRequest request) {
+        return indexNameExpressionResolver.resolveDateMathExpression(request.index());
+    }
 }

--- a/server/src/main/java/org/opensearch/action/admin/indices/datastream/CreateDataStreamAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/datastream/CreateDataStreamAction.java
@@ -37,6 +37,7 @@ import org.opensearch.action.IndicesRequest;
 import org.opensearch.action.ValidateActions;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.action.support.TransportIndicesResolvingAction;
 import org.opensearch.action.support.clustermanager.AcknowledgedRequest;
 import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction;
@@ -46,6 +47,7 @@ import org.opensearch.cluster.block.ClusterBlockLevel;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.metadata.MetadataCreateDataStreamService;
 import org.opensearch.cluster.metadata.MetadataCreateDataStreamService.CreateDataStreamClusterStateUpdateRequest;
+import org.opensearch.cluster.metadata.ResolvedIndices;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.inject.Inject;
@@ -137,7 +139,9 @@ public class CreateDataStreamAction extends ActionType<AcknowledgedResponse> {
      *
      * @opensearch.internal
      */
-    public static class TransportAction extends TransportClusterManagerNodeAction<Request, AcknowledgedResponse> {
+    public static class TransportAction extends TransportClusterManagerNodeAction<Request, AcknowledgedResponse>
+        implements
+            TransportIndicesResolvingAction<Request> {
 
         private final MetadataCreateDataStreamService metadataCreateDataStreamService;
 
@@ -178,6 +182,11 @@ public class CreateDataStreamAction extends ActionType<AcknowledgedResponse> {
         @Override
         protected ClusterBlockException checkBlock(Request request, ClusterState state) {
             return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        }
+
+        @Override
+        public ResolvedIndices resolveIndices(Request request) {
+            return ResolvedIndices.of(request.name);
         }
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/exists/indices/TransportIndicesExistsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/exists/indices/TransportIndicesExistsAction.java
@@ -34,11 +34,13 @@ package org.opensearch.action.admin.indices.exists.indices;
 
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.action.support.TransportIndicesResolvingAction;
 import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeReadAction;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.block.ClusterBlockException;
 import org.opensearch.cluster.block.ClusterBlockLevel;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.metadata.ResolvedIndices;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
@@ -54,7 +56,9 @@ import java.io.IOException;
  *
  * @opensearch.internal
  */
-public class TransportIndicesExistsAction extends TransportClusterManagerNodeReadAction<IndicesExistsRequest, IndicesExistsResponse> {
+public class TransportIndicesExistsAction extends TransportClusterManagerNodeReadAction<IndicesExistsRequest, IndicesExistsResponse>
+    implements
+        TransportIndicesResolvingAction<IndicesExistsRequest> {
 
     @Inject
     public TransportIndicesExistsAction(
@@ -118,5 +122,11 @@ public class TransportIndicesExistsAction extends TransportClusterManagerNodeRea
             exists = false;
         }
         listener.onResponse(new IndicesExistsResponse(exists));
+    }
+
+    @Override
+    public ResolvedIndices resolveIndices(IndicesExistsRequest request) {
+        // TODO this is likely not correct
+        return ResolvedIndices.of(indexNameExpressionResolver.resolveExpressions(clusterService.state(), request.indices()));
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
@@ -37,6 +37,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.action.RequestValidators;
 import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.TransportIndicesResolvingAction;
 import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction;
 import org.opensearch.cluster.ClusterState;
@@ -45,6 +46,7 @@ import org.opensearch.cluster.block.ClusterBlockException;
 import org.opensearch.cluster.block.ClusterBlockLevel;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.metadata.MetadataMappingService;
+import org.opensearch.cluster.metadata.ResolvedIndices;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
@@ -68,7 +70,9 @@ import java.util.Optional;
  *
  * @opensearch.internal
  */
-public class TransportPutMappingAction extends TransportClusterManagerNodeAction<PutMappingRequest, AcknowledgedResponse> {
+public class TransportPutMappingAction extends TransportClusterManagerNodeAction<PutMappingRequest, AcknowledgedResponse>
+    implements
+        TransportIndicesResolvingAction<PutMappingRequest> {
 
     private static final Logger logger = LogManager.getLogger(TransportPutMappingAction.class);
 
@@ -148,6 +152,11 @@ public class TransportPutMappingAction extends TransportClusterManagerNodeAction
             logger.debug(() -> new ParameterizedMessage("failed to put mappings on indices [{}]", Arrays.asList(request.indices())), ex);
             throw ex;
         }
+    }
+
+    @Override
+    public ResolvedIndices resolveIndices(PutMappingRequest request) {
+        return ResolvedIndices.of(resolveIndices(clusterService.state(), request, indexNameExpressionResolver));
     }
 
     static Index[] resolveIndices(final ClusterState state, PutMappingRequest request, final IndexNameExpressionResolver iner) {

--- a/server/src/main/java/org/opensearch/action/admin/indices/rollover/TransportRolloverAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/rollover/TransportRolloverAction.java
@@ -39,6 +39,7 @@ import org.opensearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.ActiveShardsObserver;
 import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.action.support.TransportIndicesResolvingAction;
 import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.ClusterStateUpdateTask;
@@ -47,6 +48,7 @@ import org.opensearch.cluster.block.ClusterBlocks;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.metadata.ResolvedIndices;
 import org.opensearch.cluster.service.ClusterManagerTaskThrottler;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Nullable;
@@ -77,7 +79,9 @@ import static org.opensearch.cluster.service.ClusterManagerTask.ROLLOVER_INDEX;
  *
  * @opensearch.internal
  */
-public class TransportRolloverAction extends TransportClusterManagerNodeAction<RolloverRequest, RolloverResponse> {
+public class TransportRolloverAction extends TransportClusterManagerNodeAction<RolloverRequest, RolloverResponse>
+    implements
+        TransportIndicesResolvingAction<RolloverRequest> {
 
     private final MetadataRolloverService rolloverService;
     private final ActiveShardsObserver activeShardsObserver;
@@ -260,6 +264,29 @@ public class TransportRolloverAction extends TransportClusterManagerNodeAction<R
         });
     }
 
+    @Override
+    public ResolvedIndices resolveIndices(RolloverRequest rolloverRequest) {
+        try {
+            MetadataRolloverService.RolloverResult preResult = rolloverService.rolloverClusterState(
+                clusterService.state(),
+                rolloverRequest.getRolloverTarget(),
+                rolloverRequest.getNewIndexName(),
+                rolloverRequest.getCreateIndexRequest(),
+                Collections.emptyList(),
+                true,
+                true
+            );
+
+            return ResolvedIndices.of(preResult.sourceIndexName, preResult.rolloverIndexName);
+        } catch (Exception e) {
+            // Exceptions are mostly occurring due to validation errors (e.g. non-existing indices).
+            // These are not propagated to the caller because it should be still
+            // the clusterManagerOperation() that should report these failures.
+            // Instead, we return a basic result which still allows privilege evaluation.
+            return ResolvedIndices.ofNonNull(rolloverRequest.getNewIndexName(), rolloverRequest.getRolloverTarget());
+        }
+    }
+
     static Map<String, Boolean> evaluateConditions(
         final Collection<Condition<?>> conditions,
         @Nullable final DocsStats docsStats,
@@ -291,4 +318,5 @@ public class TransportRolloverAction extends TransportClusterManagerNodeAction<R
             return evaluateConditions(conditions, docsStats, metadata);
         }
     }
+
 }

--- a/server/src/main/java/org/opensearch/action/admin/indices/shrink/TransportResizeAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/shrink/TransportResizeAction.java
@@ -37,6 +37,7 @@ import org.opensearch.action.admin.indices.create.CreateIndexClusterStateUpdateR
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.admin.indices.stats.IndexShardStats;
 import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.TransportIndicesResolvingAction;
 import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.block.ClusterBlockException;
@@ -44,6 +45,7 @@ import org.opensearch.cluster.block.ClusterBlockLevel;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.metadata.MetadataCreateIndexService;
+import org.opensearch.cluster.metadata.ResolvedIndices;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
@@ -78,7 +80,9 @@ import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REMOTE_STORE
  *
  * @opensearch.internal
  */
-public class TransportResizeAction extends TransportClusterManagerNodeAction<ResizeRequest, ResizeResponse> {
+public class TransportResizeAction extends TransportClusterManagerNodeAction<ResizeRequest, ResizeResponse>
+    implements
+        TransportIndicesResolvingAction<ResizeRequest> {
     private final MetadataCreateIndexService createIndexService;
     private final Client client;
 
@@ -143,8 +147,8 @@ public class TransportResizeAction extends TransportClusterManagerNodeAction<Res
     ) {
 
         // there is no need to fetch docs stats for split but we keep it simple and do it anyway for simplicity of the code
-        final String sourceIndex = indexNameExpressionResolver.resolveDateMathExpression(resizeRequest.getSourceIndex());
-        final String targetIndex = indexNameExpressionResolver.resolveDateMathExpression(resizeRequest.getTargetIndexRequest().index());
+        final String sourceIndex = resolveSourceIndex(resizeRequest);
+        final String targetIndex = resolveTargetIndex(resizeRequest);
         IndexMetadata indexMetadata = state.metadata().index(sourceIndex);
         ClusterSettings clusterSettings = clusterService.getClusterSettings();
         if (resizeRequest.getResizeType().equals(ResizeType.SHRINK)
@@ -220,6 +224,11 @@ public class TransportResizeAction extends TransportClusterManagerNodeAction<Res
                 }));
         }
 
+    }
+
+    @Override
+    public ResolvedIndices resolveIndices(ResizeRequest resizeRequest) {
+        return ResolvedIndices.of(resolveSourceIndex(resizeRequest), resolveTargetIndex(resizeRequest));
     }
 
     // static for unittesting this method
@@ -409,5 +418,13 @@ public class TransportResizeAction extends TransportClusterManagerNodeAction<Res
                 );
             }
         }
+    }
+
+    private String resolveSourceIndex(ResizeRequest resizeRequest) {
+        return indexNameExpressionResolver.resolveDateMathExpression(resizeRequest.getSourceIndex());
+    }
+
+    private String resolveTargetIndex(ResizeRequest resizeRequest) {
+        return indexNameExpressionResolver.resolveDateMathExpression(resizeRequest.getTargetIndexRequest().index());
     }
 }

--- a/server/src/main/java/org/opensearch/action/bulk/BulkShardRequest.java
+++ b/server/src/main/java/org/opensearch/action/bulk/BulkShardRequest.java
@@ -74,6 +74,10 @@ public class BulkShardRequest extends ReplicatedWriteRequest<BulkShardRequest> i
 
     @Override
     public String[] indices() {
+        // TODO: The following comment was possibly true on Elasticsearch, but it is not
+        // true on OpenSearch. Authorization also works with index names if an alias
+        // grants privileges for that particular index name.
+        // Thus, question: Shall we change this?
         // A bulk shard request encapsulates items targeted at a specific shard of an index.
         // However, items could be targeting aliases of the index, so the bulk request although
         // targeting a single concrete index shard might do so using several alias names.

--- a/server/src/main/java/org/opensearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/opensearch/action/bulk/TransportBulkAction.java
@@ -865,7 +865,7 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
      *
      * @opensearch.internal
      */
-    private static class ConcreteIndices {
+    static class ConcreteIndices {
         private final ClusterState state;
         private final IndexNameExpressionResolver indexNameExpressionResolver;
         private final Map<String, Index> indices = new HashMap<>();

--- a/server/src/main/java/org/opensearch/action/bulk/TransportShardBulkAction.java
+++ b/server/src/main/java/org/opensearch/action/bulk/TransportShardBulkAction.java
@@ -47,6 +47,7 @@ import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.ChannelActionListener;
+import org.opensearch.action.support.TransportIndicesResolvingAction;
 import org.opensearch.action.support.replication.ReplicationMode;
 import org.opensearch.action.support.replication.ReplicationOperation;
 import org.opensearch.action.support.replication.ReplicationTask;
@@ -61,6 +62,7 @@ import org.opensearch.cluster.action.index.MappingUpdatedAction;
 import org.opensearch.cluster.action.shard.ShardStateAction;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.MappingMetadata;
+import org.opensearch.cluster.metadata.ResolvedIndices;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.routing.AllocationId;
 import org.opensearch.cluster.routing.ShardRouting;
@@ -122,7 +124,9 @@ import java.util.function.LongSupplier;
  *
  * @opensearch.internal
  */
-public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequest, BulkShardRequest, BulkShardResponse> {
+public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequest, BulkShardRequest, BulkShardResponse>
+    implements
+        TransportIndicesResolvingAction<BulkShardRequest> {
 
     public static final String ACTION_NAME = BulkAction.NAME + "[s]";
 
@@ -215,6 +219,11 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
         } catch (RuntimeException e) {
             listener.onFailure(e);
         }
+    }
+
+    @Override
+    public ResolvedIndices resolveIndices(BulkShardRequest request) {
+        return ResolvedIndices.of(request.shardId().getIndexName());
     }
 
     /**

--- a/server/src/main/java/org/opensearch/action/delete/TransportDeleteAction.java
+++ b/server/src/main/java/org/opensearch/action/delete/TransportDeleteAction.java
@@ -35,6 +35,7 @@ package org.opensearch.action.delete;
 import org.opensearch.action.bulk.TransportBulkAction;
 import org.opensearch.action.bulk.TransportSingleItemBulkWriteAction;
 import org.opensearch.action.support.ActionFilters;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.transport.TransportService;
 
@@ -49,7 +50,12 @@ import org.opensearch.transport.TransportService;
 public class TransportDeleteAction extends TransportSingleItemBulkWriteAction<DeleteRequest, DeleteResponse> {
 
     @Inject
-    public TransportDeleteAction(TransportService transportService, ActionFilters actionFilters, TransportBulkAction bulkAction) {
-        super(DeleteAction.NAME, transportService, actionFilters, DeleteRequest::new, bulkAction);
+    public TransportDeleteAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        TransportBulkAction bulkAction,
+        IndexNameExpressionResolver indexNameExpressionResolver
+    ) {
+        super(DeleteAction.NAME, transportService, actionFilters, DeleteRequest::new, bulkAction, indexNameExpressionResolver);
     }
 }

--- a/server/src/main/java/org/opensearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/opensearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
@@ -35,8 +35,10 @@ package org.opensearch.action.fieldcaps;
 import org.opensearch.action.OriginalIndices;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.action.support.TransportIndicesResolvingAction;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.metadata.ResolvedIndices;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.util.concurrent.CountDown;
@@ -63,7 +65,9 @@ import java.util.Set;
  *
  * @opensearch.internal
  */
-public class TransportFieldCapabilitiesAction extends HandledTransportAction<FieldCapabilitiesRequest, FieldCapabilitiesResponse> {
+public class TransportFieldCapabilitiesAction extends HandledTransportAction<FieldCapabilitiesRequest, FieldCapabilitiesResponse>
+    implements
+        TransportIndicesResolvingAction<FieldCapabilitiesRequest> {
     private final ThreadPool threadPool;
     private final ClusterService clusterService;
     private final TransportFieldCapabilitiesIndexAction shardAction;
@@ -91,21 +95,11 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
     protected void doExecute(Task task, FieldCapabilitiesRequest request, final ActionListener<FieldCapabilitiesResponse> listener) {
         // retrieve the initial timestamp in case the action is a cross cluster search
         long nowInMillis = request.nowInMillis() == null ? System.currentTimeMillis() : request.nowInMillis();
-        final ClusterState clusterState = clusterService.state();
-        final Map<String, OriginalIndices> remoteClusterIndices = remoteClusterService.groupIndices(
-            request.indicesOptions(),
-            request.indices(),
-            idx -> indexNameExpressionResolver.hasIndexAbstraction(idx, clusterState)
-        );
-        final OriginalIndices localIndices = remoteClusterIndices.remove(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
-        final String[] concreteIndices;
-        if (localIndices == null) {
-            // in the case we have one or more remote indices but no local we don't expand to all local indices and just do remote indices
-            concreteIndices = Strings.EMPTY_ARRAY;
-        } else {
-            concreteIndices = indexNameExpressionResolver.concreteIndexNames(clusterState, localIndices);
-        }
-        final int totalNumRequest = concreteIndices.length + remoteClusterIndices.size();
+        ResolvedIndices allResolvedIndices = resolveIndices(request, clusterService.state());
+        Set<String> concreteIndices = allResolvedIndices.local().names();
+        Map<String, OriginalIndices> remoteClusterIndices = allResolvedIndices.remote();
+        OriginalIndices localIndices = allResolvedIndices.local().originalIndices();
+        final int totalNumRequest = concreteIndices.size() + remoteClusterIndices.size();
         final CountDown completionCounter = new CountDown(totalNumRequest);
         final List<FieldCapabilitiesIndexResponse> indexResponses = Collections.synchronizedList(new ArrayList<>());
         final Runnable onResponse = () -> {
@@ -169,6 +163,29 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
                 }, failure -> onResponse.run()));
             }
         }
+    }
+
+    @Override
+    public ResolvedIndices resolveIndices(FieldCapabilitiesRequest request) {
+        return resolveIndices(request, clusterService.state());
+    }
+
+    private ResolvedIndices resolveIndices(FieldCapabilitiesRequest request, ClusterState clusterState) {
+        final Map<String, OriginalIndices> remoteClusterIndices = remoteClusterService.groupIndices(
+            request.indicesOptions(),
+            request.indices(),
+            idx -> indexNameExpressionResolver.hasIndexAbstraction(idx, clusterState)
+        );
+        final OriginalIndices localIndices = remoteClusterIndices.remove(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
+        final String[] concreteIndices;
+        if (localIndices == null) {
+            // in the case we have one or more remote indices but no local we don't expand to all local indices and just do remote indices
+            concreteIndices = Strings.EMPTY_ARRAY;
+        } else {
+            concreteIndices = indexNameExpressionResolver.concreteIndexNames(clusterState, localIndices);
+        }
+
+        return ResolvedIndices.of(concreteIndices).withLocalOriginalIndices(localIndices).withRemoteIndices(remoteClusterIndices);
     }
 
     private FieldCapabilitiesResponse merge(List<FieldCapabilitiesIndexResponse> indexResponses, boolean includeUnmapped) {

--- a/server/src/main/java/org/opensearch/action/index/TransportIndexAction.java
+++ b/server/src/main/java/org/opensearch/action/index/TransportIndexAction.java
@@ -35,6 +35,7 @@ package org.opensearch.action.index;
 import org.opensearch.action.bulk.TransportBulkAction;
 import org.opensearch.action.bulk.TransportSingleItemBulkWriteAction;
 import org.opensearch.action.support.ActionFilters;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.transport.TransportService;
 
@@ -56,7 +57,12 @@ import org.opensearch.transport.TransportService;
 public class TransportIndexAction extends TransportSingleItemBulkWriteAction<IndexRequest, IndexResponse> {
 
     @Inject
-    public TransportIndexAction(ActionFilters actionFilters, TransportService transportService, TransportBulkAction bulkAction) {
-        super(IndexAction.NAME, transportService, actionFilters, IndexRequest::new, bulkAction);
+    public TransportIndexAction(
+        ActionFilters actionFilters,
+        TransportService transportService,
+        TransportBulkAction bulkAction,
+        IndexNameExpressionResolver indexNameExpressionResolver
+    ) {
+        super(IndexAction.NAME, transportService, actionFilters, IndexRequest::new, bulkAction, indexNameExpressionResolver);
     }
 }

--- a/server/src/main/java/org/opensearch/action/support/ActionFilter.java
+++ b/server/src/main/java/org/opensearch/action/support/ActionFilter.java
@@ -57,6 +57,7 @@ public interface ActionFilter {
         Task task,
         String action,
         Request request,
+        ActionRequestMetadata<Request, Response> actionRequestMetadata,
         ActionListener<Response> listener,
         ActionFilterChain<Request, Response> chain
     );
@@ -72,6 +73,7 @@ public interface ActionFilter {
             Task task,
             String action,
             Request request,
+            ActionRequestMetadata<Request, Response> actionRequestMetadata,
             ActionListener<Response> listener,
             ActionFilterChain<Request, Response> chain
         ) {

--- a/server/src/main/java/org/opensearch/action/support/ActionRequestMetadata.java
+++ b/server/src/main/java/org/opensearch/action/support/ActionRequestMetadata.java
@@ -1,0 +1,78 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.support;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.cluster.metadata.ResolvedIndices;
+import org.opensearch.core.action.ActionResponse;
+
+import java.util.Optional;
+
+/**
+ * This class can be used to provide metadata about action requests to ActionFilter implementations.
+ * At the moment, this class provides information about the requested indices of a request, but it can be
+ * extended to transport further metadata.
+ */
+public class ActionRequestMetadata<Request extends ActionRequest, Response extends ActionResponse> {
+
+    /**
+     * Returns an empty meta data object which will just report unknown results.
+     */
+    public static <Request extends ActionRequest, Response extends ActionResponse> ActionRequestMetadata<Request, Response> empty() {
+        @SuppressWarnings("unchecked")
+        ActionRequestMetadata<Request, Response> result = (ActionRequestMetadata<Request, Response>) EMPTY;
+        return result;
+    }
+
+    private static final ActionRequestMetadata<?, ?> EMPTY = new ActionRequestMetadata<>(null, null);
+
+    private final TransportAction<Request, Response> transportAction;
+    private final Request request;
+
+    private ResolvedIndices resolvedIndices;
+    private boolean resolvedIndicesInitialized;
+
+    ActionRequestMetadata(TransportAction<Request, Response> transportAction, Request request) {
+        this.transportAction = transportAction;
+        this.request = request;
+    }
+
+    /**
+     * If the current action request references indices, this method actually referenced indices. That means that any
+     * expressions or patterns will be resolved.
+     * <p>
+     * If the request cannot reference indices OR if the respective action does not support resolving of requests,
+     * this returns an empty Optional.
+     */
+    public Optional<ResolvedIndices> resolvedIndices() {
+        if (!(transportAction instanceof TransportIndicesResolvingAction<?>)) {
+            return Optional.empty();
+        }
+
+        if (this.resolvedIndicesInitialized) {
+            return Optional.of(this.resolvedIndices);
+        } else {
+            return resolveIndices();
+        }
+    }
+
+    /**
+     * Performs the actual index resolution. Index resolution can be relatively costly on big clusters, so we
+     * perform it lazily only when requested.
+     */
+    private Optional<ResolvedIndices> resolveIndices() {
+        @SuppressWarnings("unchecked")
+        TransportIndicesResolvingAction<Request> indicesResolvingAction = (TransportIndicesResolvingAction<Request>) this.transportAction;
+        ResolvedIndices result = indicesResolvingAction.resolveIndices(request);
+
+        this.resolvedIndices = result;
+        this.resolvedIndicesInitialized = true;
+        return Optional.of(result);
+    }
+}

--- a/server/src/main/java/org/opensearch/action/support/TransportAction.java
+++ b/server/src/main/java/org/opensearch/action/support/TransportAction.java
@@ -215,7 +215,7 @@ public abstract class TransportAction<Request extends ActionRequest, Response ex
             int i = index.getAndIncrement();
             try {
                 if (i < this.action.filters.length) {
-                    this.action.filters[i].apply(task, actionName, request, listener, this);
+                    this.action.filters[i].apply(task, actionName, request, new ActionRequestMetadata<>(action, request), listener, this);
                 } else if (i == this.action.filters.length) {
                     this.action.doExecute(task, request, listener);
                 } else {

--- a/server/src/main/java/org/opensearch/action/support/TransportIndicesResolvingAction.java
+++ b/server/src/main/java/org/opensearch/action/support/TransportIndicesResolvingAction.java
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.support;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.cluster.metadata.ResolvedIndices;
+
+/**
+ * An additional interface that should be implemented by TransportAction implementations which need to resolve
+ * IndicesRequests or other action requests which specify indices. This interface allows other components to retrieve
+ * precise information about the indices an action is going to operate on. This is particularly useful for access
+ * control implementations, but can be also used for other purposes, such as monitoring, audit logging, etc.
+ * <p>
+ * Classes implementing this interface should make sure that the reported indices are also actually the indices
+ * the action will operate on. The best way to achieve this, is to move the index extraction code from the execute
+ * methods into reusable methods and to depend on these both for execution and reporting.
+ */
+public interface TransportIndicesResolvingAction<Request extends ActionRequest> {
+
+    /**
+     * Returns the actual indices the action will operate on, given the specified request and cluster state.
+     */
+    ResolvedIndices resolveIndices(Request request);
+}

--- a/server/src/main/java/org/opensearch/action/support/replication/TransportReplicationAction.java
+++ b/server/src/main/java/org/opensearch/action/support/replication/TransportReplicationAction.java
@@ -43,6 +43,7 @@ import org.opensearch.action.support.ActiveShardCount;
 import org.opensearch.action.support.ChannelActionListener;
 import org.opensearch.action.support.TransportAction;
 import org.opensearch.action.support.TransportActions;
+import org.opensearch.action.support.TransportIndicesResolvingAction;
 import org.opensearch.action.support.replication.ReplicationOperation.Replicas;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.ClusterStateObserver;
@@ -50,6 +51,7 @@ import org.opensearch.cluster.action.shard.ShardStateAction;
 import org.opensearch.cluster.block.ClusterBlockException;
 import org.opensearch.cluster.block.ClusterBlockLevel;
 import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.ResolvedIndices;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.routing.AllocationId;
 import org.opensearch.cluster.routing.ShardRouting;
@@ -111,7 +113,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public abstract class TransportReplicationAction<
     Request extends ReplicationRequest<Request>,
     ReplicaRequest extends ReplicationRequest<ReplicaRequest>,
-    Response extends ReplicationResponse> extends TransportAction<Request, Response> {
+    Response extends ReplicationResponse> extends TransportAction<Request, Response> implements TransportIndicesResolvingAction<Request> {
 
     /**
      * The timeout for retrying replication requests.
@@ -316,6 +318,11 @@ public abstract class TransportReplicationAction<
     protected void doExecute(Task task, Request request, ActionListener<Response> listener) {
         assert request.shardId() != null : "request shardId must be set";
         runReroutePhase(task, request, listener, true);
+    }
+
+    @Override
+    public ResolvedIndices resolveIndices(Request request) {
+        return ResolvedIndices.of(request.index);
     }
 
     private void runReroutePhase(Task task, Request request, ActionListener<Response> listener, boolean initiatedByNodeClient) {

--- a/server/src/main/java/org/opensearch/cluster/metadata/ResolvedIndices.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/ResolvedIndices.java
@@ -1,0 +1,154 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.metadata;
+
+import org.opensearch.action.OriginalIndices;
+import org.opensearch.core.index.Index;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * A class that encapsulates resolved indices. Resolved indices do not any wildcards or date math expressions.
+ * However, in contrast to the concept of "concrete indices", resolved indices might not exist yet, or might
+ * refer to aliases or data streams.
+ * <p>
+ * ResolvedIndices classes are primarily created by the resolveIndices() method in TransportIndicesResolvingAction.
+ * <p>
+ * How resolved indices are obtained depends on the respective action and the associated requests:
+ * <ul>
+ *     <li>If a request carries an index expression (i.e, might contain patterns or date math expressions), the index
+ *     expression must be resolved using the appropriate index options; these might be request-specific or action-specific.</li>
+ *     <li>Some requests already carry concrete indices; in these cases, the names of the concrete indices can be
+ *     just taken without further evaluation</li>
+ * </ul>
+ */
+public class ResolvedIndices {
+    public static ResolvedIndices of(String... indices) {
+        return new ResolvedIndices(
+            new Local(Collections.unmodifiableSet(new HashSet<>(Arrays.asList(indices))), null, false),
+            Collections.emptyMap()
+        );
+    }
+
+    public static ResolvedIndices of(Index... indices) {
+        return new ResolvedIndices(
+            new Local(Stream.of(indices).map(Index::getName).collect(Collectors.toUnmodifiableSet()), null, false),
+            Collections.emptyMap()
+        );
+    }
+
+    public static ResolvedIndices of(Collection<String> indices) {
+        return new ResolvedIndices(new Local(Collections.unmodifiableSet(new HashSet<>(indices)), null, false), Collections.emptyMap());
+    }
+
+    public static ResolvedIndices all() {
+        return ALL;
+    }
+
+    public static ResolvedIndices ofNonNull(String... indices) {
+        Set<String> indexSet = new HashSet<>(indices.length);
+
+        for (String index : indices) {
+            if (index != null) {
+                indexSet.add(index);
+            }
+        }
+
+        return new ResolvedIndices(new Local(Collections.unmodifiableSet(indexSet), null, false), Collections.emptyMap());
+    }
+
+    private static final ResolvedIndices ALL = new ResolvedIndices(new Local(Set.of(Metadata.ALL), null, true), Collections.emptyMap());
+
+    private final Local local;
+    private final Map<String, OriginalIndices> remote;
+
+    private ResolvedIndices(Local local, Map<String, OriginalIndices> remote) {
+        this.local = local;
+        this.remote = remote;
+    }
+
+    public Local local() {
+        return this.local;
+    }
+
+    public Map<String, OriginalIndices> remote() {
+        return this.remote;
+    }
+
+    public ResolvedIndices withRemoteIndices(Map<String, OriginalIndices> remoteIndices) {
+        if (remoteIndices.isEmpty()) {
+            return this;
+        }
+
+        Map<String, OriginalIndices> newRemoteIndices = new HashMap<>(remoteIndices);
+        newRemoteIndices.putAll(this.remote);
+
+        return new ResolvedIndices(this.local, Collections.unmodifiableMap(newRemoteIndices));
+    }
+
+    public ResolvedIndices withLocalOriginalIndices(OriginalIndices originalIndices) {
+        return new ResolvedIndices(new Local(this.local.names, originalIndices, this.local.isAll), this.remote);
+    }
+
+    public boolean isEmpty() {
+        return this.local.isEmpty() && this.remote.isEmpty();
+    }
+
+    /**
+     * Encapsulates the local (i.e., non-remote) indices referenced by the respective request.
+     */
+    public static class Local {
+        private final Set<String> names;
+        private final OriginalIndices originalIndices;
+        private final boolean isAll;
+
+        private Local(Set<String> names, OriginalIndices originalIndices, boolean isAll) {
+            this.names = names;
+            this.originalIndices = originalIndices;
+            this.isAll = isAll;
+        }
+
+        public Set<String> names() {
+            return this.names;
+        }
+
+        public String[] namesAsArray() {
+            return this.names.toArray(new String[0]);
+        }
+
+        public OriginalIndices originalIndices() {
+            return this.originalIndices;
+        }
+
+        public boolean isEmpty() {
+            if (this.isAll) {
+                return false;
+            } else {
+                return this.names.isEmpty();
+            }
+        }
+
+        public boolean contains(String index) {
+            if (this.isAll) {
+                return true;
+            } else {
+                return this.names.contains(index);
+            }
+        }
+    }
+
+}

--- a/server/src/test/java/org/opensearch/action/bulk/TransportBulkActionIngestTests.java
+++ b/server/src/test/java/org/opensearch/action/bulk/TransportBulkActionIngestTests.java
@@ -224,7 +224,8 @@ public class TransportBulkActionIngestTests extends OpenSearchSingleNodeTestCase
                 TransportBulkActionIngestTests.this.transportService,
                 new ActionFilters(Collections.emptySet()),
                 IndexRequest::new,
-                bulkAction
+                bulkAction,
+                new IndexNameExpressionResolver(new ThreadContext(Settings.EMPTY))
             );
         }
     }

--- a/server/src/test/java/org/opensearch/action/support/TransportActionFilterChainTests.java
+++ b/server/src/test/java/org/opensearch/action/support/TransportActionFilterChainTests.java
@@ -243,6 +243,7 @@ public class TransportActionFilterChainTests extends OpenSearchTestCase {
             Task task,
             String action,
             Request request,
+            ActionRequestMetadata<Request, Response> actionRequestMetadata,
             ActionListener<Response> listener,
             ActionFilterChain<Request, Response> chain
         ) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

This introduces a new method that allows `TransportAction` implementations to report the indices the will actually operate on via a standard API to any `ActionFilter` implementation.  This can be then used for example by access control filters to check authorization.

This has several advantages:

- Actually, the way transport actions interpret indices specified in `IndicesRequests` is extremely diverse. Some do resolution of all expressions and rely on index options, some do resolution of all expressions and modify index options, some do only date math expression resolution, and some do no resolution at all. This change makes gives a method to make it very explicit which indices will be touched by an action.
- Actually, the case where no resolution happens at all is quite common - that's the case for most shard-based actions. This allows us to avoid a costly resolution for all these cases. This should give a significant performance boost.

Note: This is not complete yet and is intended only as a sneak-peek.



### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
